### PR TITLE
beman-tidy: add check - README.LIBRARY_STATUS

### DIFF
--- a/tools/beman-tidy/lib/checks/beman_standard/readme.py
+++ b/tools/beman-tidy/lib/checks/beman_standard/readme.py
@@ -72,3 +72,28 @@ class ReadmeBadgesCheck(ReadmeBaseCheck):
 
 
 # TODO README.LIBRARY_STATUS
+@register_beman_standard_check("README.LIBRARY_STATUS")
+class ReadmeLibraryStatusCheck(ReadmeBaseCheck):
+    def __init__(self, repo_info, beman_standard_check_config):
+        super().__init__(repo_info, beman_standard_check_config)
+
+    def check(self):
+        """
+        self.config["values"] contains a fixed set of Beman library statuses.
+        """
+        statuses = self.config["values"]
+        assert len(statuses) == len(self.beman_library_maturity_model)
+
+        # Check if at least one of the required status values is present.
+        status_count = len(
+            [status for status in statuses if self.has_content(status)])
+        if status_count != 1:
+            self.log(
+                f"The file '{self.path}' does not contain exactly one of the required statuses from {statuses}")
+            return False
+
+        return True
+
+    def fix(self):
+        # TODO: Implement the fix.
+        pass

--- a/tools/beman-tidy/lib/pipeline.py
+++ b/tools/beman-tidy/lib/pipeline.py
@@ -13,7 +13,7 @@ from .checks.system.git import DisallowFixInplaceAndUnstagedChangesCheck
 # from .checks.beman_standard.file import
 # from .checks.beman_standard.general import
 # from .checks.beman_standard.license import
-from .checks.beman_standard.readme import ReadmeTitleCheck, ReadmeBadgesCheck
+from .checks.beman_standard.readme import ReadmeTitleCheck, ReadmeBadgesCheck, ReadmeLibraryStatusCheck
 # from .checks.beman_standard.release import
 # from .checks.beman_standard.toplevel import
 

--- a/tools/beman-tidy/tests/beman_standard/readme/data/invalid/invalid-status-line-v1.md
+++ b/tools/beman-tidy/tests/beman_standard/readme/data/invalid/invalid-status-line-v1.md
@@ -1,0 +1,14 @@
+## beman.exemplar: A Beman Library Exemplar
+
+<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
+
+<!-- markdownlint-disable-next-line line-length -->
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
+
+**Purpose**: `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
+
+**Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
+
+**Status**: Under development and not yet ready for production use.
+
+This is NOT a valid README.md according to the Beman Standard: the library status is not properly formatted.

--- a/tools/beman-tidy/tests/beman_standard/readme/data/invalid/invalid-status-line-v2.md
+++ b/tools/beman-tidy/tests/beman_standard/readme/data/invalid/invalid-status-line-v2.md
@@ -1,0 +1,15 @@
+# beman.exemplar: A Beman Library Exemplar
+
+<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
+
+<!-- markdownlint-disable-next-line line-length -->
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
+
+**Purpose**: `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
+
+**Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
+
+**Status**: [under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md# TYPO HERE under-development-and-not-yet-ready-for-production-use)
+
+This is NOT a valid README.md according to the Beman Standard: the library status line has typos.
+

--- a/tools/beman-tidy/tests/beman_standard/readme/data/invalid/invalid-status-line-v3.md
+++ b/tools/beman-tidy/tests/beman_standard/readme/data/invalid/invalid-status-line-v3.md
@@ -1,0 +1,18 @@
+# beman.exemplar: A Beman Library Exemplar
+
+<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
+
+<!-- markdownlint-disable-next-line line-length -->
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
+
+**Purpose**: `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
+
+**Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
+
+**Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use),
+**Status**: [Production ready. API may undergo changes.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-api-may-undergo-changes),
+**Status**: [Production ready. Stable API.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-stable-api),
+**Status**: [Retired. No longer maintained or actively developed.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#retired-no-longer-maintained-or-actively-developed),
+
+This is NOT a valid README.md according to the Beman Standard: the library status is duplicated.
+

--- a/tools/beman-tidy/tests/beman_standard/readme/test_readme.py
+++ b/tools/beman-tidy/tests/beman_standard/readme/test_readme.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from tests.utils.file_testcase_runners import file_testcases_run_valid, file_testcases_run_invalid, file_testcases_run_fix_invalid
 # Actual tested checks.
-from lib.checks.beman_standard.readme import ReadmeTitleCheck, ReadmeBadgesCheck
+from lib.checks.beman_standard.readme import ReadmeTitleCheck, ReadmeBadgesCheck, ReadmeLibraryStatusCheck
 
 
 def test__README_TITLE__valid(repo_info, beman_standard_check_config):
@@ -82,4 +82,36 @@ def test__README_BADGES__invalid(repo_info, beman_standard_check_config, invalid
 @pytest.mark.skip(reason="NOT implemented")
 def test__README_BADGES__fix_invalid(repo_info, beman_standard_check_config, invalid_readme_path, valid_readme_path):
     """Test that the fix method corrects an invalid README.md badges"""
+    pass
+
+
+def test__README_LIBRARY_STATUS__valid(repo_info, beman_standard_check_config, valid_readme_path):
+    """Test that a valid README.md library status passes the check"""
+    valid_readme_paths = [
+        Path("tests/beman_standard/readme/data/valid/README-v1.md"),
+        Path("tests/beman_standard/readme/data/valid/README-v2.md"),
+        Path("tests/beman_standard/readme/data/valid/README-v3.md"),
+        Path("tests/beman_standard/readme/data/valid/README-v4.md"),
+    ]
+
+    file_testcases_run_valid(valid_readme_paths, ReadmeLibraryStatusCheck,
+                             repo_info, beman_standard_check_config)
+
+
+def test__README_LIBRARY_STATUS__invalid(repo_info, beman_standard_check_config):
+    """Test that an invalid README.md library status fails the check"""
+    invalid_readme_paths = [
+        Path("tests/beman_standard/readme/data/invalid/invalid.md"),
+        Path("tests/beman_standard/readme/data/invalid/invalid-status-line-v1.md"),
+        Path("tests/beman_standard/readme/data/invalid/invalid-status-line-v2.md"),
+        Path("tests/beman_standard/readme/data/invalid/invalid-status-line-v3.md"),
+    ]
+
+    file_testcases_run_invalid(invalid_readme_paths, ReadmeLibraryStatusCheck,
+                               repo_info, beman_standard_check_config)
+
+
+@pytest.mark.skip(reason="NOT implemented")
+def test__README_LIBRARY_STATUS__fix_invalid(repo_info, beman_standard_check_config, invalid_readme_path, valid_readme_path):
+    """Test that the fix method corrects an invalid README.md library status"""
     pass


### PR DESCRIPTION
beman-tidy: add check - README.LIBRARY_STATUS

Note: This can be used an example of adding a file-based check (a check implementation which should validate a file from a repo given via a path).
Updates:
- Check implementation inside a file from `tools/beman-tidy/lib/checks/beman_standard/` - (e.g. `README.*` checks will be implemented in `Beman/infra/tools/beman-tidy/lib/checks/beman_standard/readme.py`.).
- Add tests (e.g., `README.*` checks will have tests in `tools/beman-tidy/tests/beman_standard/readme/test_readme.py`

Check `tools/beman-tidy/docs/dev-guide.md` for full instructions.